### PR TITLE
Fix: os error path not found

### DIFF
--- a/esy.json
+++ b/esy.json
@@ -5,10 +5,11 @@
   "description": "Rust toolchain setup for esy",
   "source": "https://github.com/rust-lang/rustup/archive/refs/tags/1.24.2.tar.gz#979e8139734d39313b0147e0db3bfd2675f49507",
   "override": {
+    "buildsInSource": true,
     "buildEnv": {
       "RUSTUP_USE_CURL": "1",
-      "CARGO_HOME": "#{self.install}",
-      "RUSTUP_HOME": "#{self.install / '.rustup'}"
+      "CARGO_HOME": "#{self.target_dir}",
+      "RUSTUP_HOME": "#{self.target_dir / '.rustup'}"
     },
     "exportedEnv": {
       "CARGO_HOME": {
@@ -26,6 +27,21 @@
         "-c",
         "./rustup-init.sh -y --no-modify-path --default-toolchain 1.51 --profile minimal #{os == 'windows' ? '--default-host=x86_64-pc-windows-gnu' : ''}"
       ]
+    ],
+    "install": [
+      "cp #{self.target_dir}/bin/cargo-fmt#{os == 'windows' ? '.exe': ''} #{self.bin}",
+      "cp #{self.target_dir}/bin/cargo-miri#{os == 'windows' ? '.exe': ''} #{self.bin}",
+      "cp #{self.target_dir}/bin/cargo#{os == 'windows' ? '.exe': ''} #{self.bin}",
+      "cp #{self.target_dir}/bin/clippy-driver#{os == 'windows' ? '.exe': ''} #{self.bin}",
+      "cp #{self.target_dir}/bin/rls#{os == 'windows' ? '.exe': ''} #{self.bin}",
+      "cp #{self.target_dir}/bin/rust-gdb#{os == 'windows' ? '.exe': ''} #{self.bin}",
+      "cp #{self.target_dir}/bin/rust-lldb#{os == 'windows' ? '.exe': ''} #{self.bin}",
+      "cp #{self.target_dir}/bin/rustc#{os == 'windows' ? '.exe': ''} #{self.bin}",
+      "cp #{self.target_dir}/bin/rustdoc#{os == 'windows' ? '.exe': ''} #{self.bin}",
+      "cp #{self.target_dir}/bin/rustfmt#{os == 'windows' ? '.exe': ''} #{self.bin}",
+      "cp #{self.target_dir}/bin/rustup#{os == 'windows' ? '.exe': ''} #{self.bin}",
+      "cp -R #{self.target_dir}/.cargo #{self.install}/.cargo",
+      "cp -R #{self.target_dir}/.rustup #{self.install}/.rustup"
     ]
   }
 }


### PR DESCRIPTION
The package keeps failing with path not found. This was likely because of long paths - using a shorter path fixed the issue.